### PR TITLE
fix: アプリ名を「ポチそぎ」から「ぽちそぎ」に変更

### DIFF
--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">ポチそぎ</string>
+    <string name="app_name">ぽちそぎ</string>
 </resources>

--- a/client/ios/Runner/Info.plist
+++ b/client/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>ポチそぎ</string>
+	<string>ぽちそぎ</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -195,7 +195,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         showLicensePage(
           context: context,
           applicationName: 'ぽちそぎ',
-          applicationLegalese: '2025 ぽちそぎ',
+          applicationLegalese: '2025 colomney',
         );
       },
     );

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -135,8 +135,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ShareParams(
             text:
                 // TODO(ide): アプリのURLを取得する
-                '家事の可視化と削減アプリ「ポチそぎ」を使ってみませんか？ ',
-            title: '家事の可視化と削減アプリ「ポチそぎ」',
+                '家事の可視化と削減アプリ「ぽちそぎ」を使ってみませんか？ ',
+            title: '家事の可視化と削減アプリ「ぽちそぎ」',
           ),
         );
       },
@@ -194,8 +194,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         // ライセンス表示画面へ遷移
         showLicensePage(
           context: context,
-          applicationName: 'ポチそぎ',
-          applicationLegalese: ' 2025 ポチそぎ',
+          applicationName: 'ぽちそぎ',
+          applicationLegalese: ' 2025 ぽちそぎ',
         );
       },
     );

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -195,7 +195,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         showLicensePage(
           context: context,
           applicationName: 'ぽちそぎ',
-          applicationLegalese: ' 2025 ぽちそぎ',
+          applicationLegalese: '2025 ぽちそぎ',
         );
       },
     );

--- a/client/lib/ui/root_app.dart
+++ b/client/lib/ui/root_app.dart
@@ -62,7 +62,7 @@ class _RootAppState extends ConsumerState<RootApp> {
     ];
 
     return MaterialApp(
-      title: 'ポチそぎ',
+      title: 'ぽちそぎ',
       theme: getLightTheme(),
       darkTheme: getDarkTheme(),
       debugShowCheckedModeBanner: showAppDebugBanner,


### PR DESCRIPTION
## 概要

アプリの日本語名を「ポチそぎ」から「ぽちそぎ」に変更しました。

## 変更理由

- 一部分だけカナ変換が必要だと、ユーザーが入力しづらくなる
- 検索のヒット率が下がる懸念

## 変更内容

- 設定画面のシェア機能とライセンス表示を更新
- iOSとAndroidの各プラットフォーム設定を更新

Fixes #196

Generated with [Claude Code](https://claude.ai/code)