### PR TITLE
fix: extend analysis period for free plan 

### DIFF
--- a/client/lib/ui/feature/analysis/analysis_presenter.dart
+++ b/client/lib/ui/feature/analysis/analysis_presenter.dart
@@ -24,7 +24,6 @@ Future<List<AnalysisPeriodSelectItem>> analysisPeriodSelectItems(
 
   // Pro限定の期間を定義
   const proOnlyPeriods = {
-    AnalysisPeriodIdentifier.pastTwoWeeks,
     AnalysisPeriodIdentifier.currentMonth,
     AnalysisPeriodIdentifier.pastMonth,
   };

--- a/client/lib/ui/feature/analysis/analysis_screen.dart
+++ b/client/lib/ui/feature/analysis/analysis_screen.dart
@@ -325,7 +325,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Pro版限定機能'),
-        content: const Text('1週間を超える期間の分析はPro版でのみ利用できます。'),
+        content: const Text('2週間を超える期間の分析はPro版でのみ利用できます。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),


### PR DESCRIPTION
## Summary
- allow analysis up to two weeks for free users
- update upgrade message accordingly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c75899308333a8ff3c58cd532eae