### PR TITLE
Add Pro feature text for longer analysis period

### DIFF
--- a/client/lib/ui/feature/analysis/analysis_screen.dart
+++ b/client/lib/ui/feature/analysis/analysis_screen.dart
@@ -214,10 +214,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
         if (snapshot.hasError) {
           return DropdownButton(
             items: const [
-              DropdownMenuItem<int>(
-                value: 0,
-                child: Text('                '),
-              ),
+              DropdownMenuItem<int>(value: 0, child: Text('                ')),
             ],
             onChanged: null,
           );
@@ -229,10 +226,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
           return Skeletonizer(
             child: DropdownButton<int>(
               items: const [
-                DropdownMenuItem<int>(
-                  value: 0,
-                  child: Text('Dummy Period'),
-                ),
+                DropdownMenuItem<int>(value: 0, child: Text('Dummy Period')),
               ],
               onChanged: null,
             ),
@@ -270,13 +264,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
       '- ${dateTimeFormat.format(analysisPeriod.to)}',
     );
 
-    return Row(
-      spacing: 8,
-      children: [
-        dropdownButton,
-        periodText,
-      ],
-    );
+    return Row(spacing: 8, children: [dropdownButton, periodText]);
   }
 
   List<DropdownMenuItem<AnalysisPeriodIdentifier>> _buildDropdownItemsSync(
@@ -292,10 +280,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           spacing: 4,
-          children: [
-            Text(label),
-            if (shouldShowProMark) const _ProMark(),
-          ],
+          children: [Text(label), if (shouldShowProMark) const _ProMark()],
         ),
       );
     }).toList();
@@ -325,7 +310,7 @@ class _AnalysisPeriodSwitcher extends ConsumerWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Pro版限定機能'),
-        content: const Text('2週間を超える期間の分析はPro版でのみ利用できます。'),
+        content: const Text('2週間を超える（最大1ヶ月までの）期間の分析はPro版でのみ利用できます。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
@@ -885,11 +870,7 @@ class _ProMark extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Icon(
-      Icons.workspace_premium,
-      size: 16,
-      color: Colors.amber,
-    );
+    return const Icon(Icons.workspace_premium, size: 16, color: Colors.amber);
   }
 }
 

--- a/client/lib/ui/feature/pro/upgrade_to_pro_screen.dart
+++ b/client/lib/ui/feature/pro/upgrade_to_pro_screen.dart
@@ -59,6 +59,13 @@ class _UpgradeToProScreenState extends ConsumerState<UpgradeToProScreen> {
             ),
             SizedBox(height: 16),
             _FeatureItem(
+              icon: Icons.analytics,
+              title: '分析期間が最大1ヶ月に',
+              description:
+                  'フリー版では2週間までの期間しか選択できませんが、Pro版では1ヶ月までの期間で家事の実行状況を分析できます。',
+            ),
+            SizedBox(height: 16),
+            _FeatureItem(
               icon: Icons.lock_clock,
               title: '今後追加される機能も使い放題',
               description: '今後追加される有料機能もすべて使えるようになります。',


### PR DESCRIPTION
## Summary
- highlight on upgrade screen that analysis period extends to one month
- clarify limit in the pro upgrade dialog

## Testing
- `dart format client/lib/ui/feature/analysis/analysis_screen.dart client/lib/ui/feature/pro/upgrade_to_pro_screen.dart`
- `dart fix --apply`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_687209727a3883338f8a3250b0a097a5