### PR TITLE
fix: update free plan note about pro features in settings screen

### DIFF
--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -525,7 +525,7 @@ class _PlanInfoTile extends StatelessWidget {
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
-              'Pro版では家事の登録件数が無制限になります',
+              'Pro版では家事の登録件数が無制限になり、分析期間を最大1ヶ月まで選択できるようになります',
               style: TextStyle(color: Colors.grey, fontSize: 14),
               textAlign: TextAlign.center,
             ),

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -522,11 +522,13 @@ class _PlanInfoTile extends StatelessWidget {
           ),
         )
         ..add(
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
               'Pro版では家事の種類が無制限に登録でき、分析期間を最大1ヶ月まで選択できるようになります',
-              style: TextStyle(color: Colors.grey, fontSize: 14),
+              style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
               textAlign: TextAlign.center,
             ),
           ),

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -525,7 +525,7 @@ class _PlanInfoTile extends StatelessWidget {
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
-              'Pro版では家事の登録件数が無制限になり、分析期間を最大1ヶ月まで選択できるようになります',
+              'Pro版では家事の種類が無制限に登録でき、分析期間を最大1ヶ月まで選択できるようになります',
               style: TextStyle(color: Colors.grey, fontSize: 14),
               textAlign: TextAlign.center,
             ),

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -111,10 +111,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     return ListTile(
       leading: leading,
       title: Text(titleText),
-      subtitle: Text(
-        'ユーザーID: ${userProfile.id}',
-        style: const TextStyle(fontSize: 12, color: Colors.grey),
-      ),
+      subtitle: Text(userProfile.id),
       onTap: onTap,
       onLongPress: () => _copyUserIdToClipboard(userProfile.id),
     );


### PR DESCRIPTION
## Summary
- update the explanatory note shown on the Settings screen for Free plan users

## Testing
- `dart format client/lib/ui/feature/settings/settings_screen.dart` *(fails: command not found)*
- `dart fix --apply` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687312c926e08333821f96797a7b9c46